### PR TITLE
HTTP -> HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 
   <p>All you need to use the ISS Tracker extension is an active internet connection.</p>
 
-  <a target="_new" href="http://scratchx.org/?url=https://khanning.github.io/scratch-isstracker-extension/iss_extension.js">Load the ISS Tracker extension on ScratchX</a>
+  <a target="_new" href="https://scratchx.org/?url=https://khanning.github.io/scratch-isstracker-extension/iss_extension.js">Load the ISS Tracker extension on ScratchX</a>
   
   <a name="blocks" />
   <h1>Scratch Blocks</h1>
@@ -81,7 +81,7 @@
   <h1>Example Projects</h1>
 
   <dl>
-    <dt><a target="_new" href="http://scratchx.org/?url=http://khanning.github.io/scratch-isstracker-extension/examples/ISS%20Tracker.sbx">ISS Tracker</a></dt>
+    <dt><a target="_new" href="https://scratchx.org/?url=https://khanning.github.io/scratch-isstracker-extension/examples/ISS%20Tracker.sbx">ISS Tracker</a></dt>
     <dd>Plot the path of the ISS as it orbits around Earth. Record the last time the ISS passes over Boston, MA.</dd>
   </dl>
 

--- a/iss_extension.js
+++ b/iss_extension.js
@@ -31,7 +31,7 @@
 
     $.ajax({
       type: "GET",
-      url: "http://nominatim.openstreetmap.org/search/",
+      url: "https://nominatim.openstreetmap.org/search/",
       dataType: "jsonp",
       data: {
         format: "json",
@@ -137,7 +137,7 @@
       loc: ['longitude', 'latitude', 'altitude', 'velocity'],
       measurements: ['kilometers', 'miles']
     },
-    url: 'http://khanning.github.io/scratch-isstracker-extension'
+    url: 'https://khanning.github.io/scratch-isstracker-extension'
   };
 
   ScratchExtensions.register('ISS Tracker', descriptor, ext);


### PR DESCRIPTION
Now that scratchx.org is behind https, extensions need to reference https when accessing sites